### PR TITLE
fix: Fix TypeScript build errors for production deployment

### DIFF
--- a/src/hooks/use-chat-stream.ts
+++ b/src/hooks/use-chat-stream.ts
@@ -176,7 +176,7 @@ export function useChatStream(
       console.error('Streaming error:', err);
 
       // Handle different error types with translations
-      let errorMessage = t.errors.genericError;
+      let errorMessage: string = t.errors.genericError;
 
       if (err instanceof APIError) {
         switch (err.code) {
@@ -220,7 +220,7 @@ export function useChatStream(
       currentStreamingMessageRef.current = null;
       setIsStreaming(false);
     }
-  }, [currentConversationId, setConversations]);
+  }, [currentConversationId, setConversations, language, t]);
 
   return {
     isStreaming,

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -101,7 +101,7 @@ export function useChat(
       console.error('Chat error:', err);
 
       // Handle different error types with translations
-      let errorMessage = t.errors.genericError;
+      let errorMessage: string = t.errors.genericError;
 
       if (err instanceof APIError) {
         switch (err.code) {
@@ -141,7 +141,7 @@ export function useChat(
     } finally {
       setIsLoading(false);
     }
-  }, [currentConversationId, setConversations]);
+  }, [currentConversationId, setConversations, language, t]);
 
   return {
     isLoading,

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import { Conversation, ChatMessage } from '@/types/chat';
+import { Conversation } from '@/types/chat';
 
 // Mock conversations for testing
 export const mockConversations: Conversation[] = [

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -104,7 +104,7 @@ export const en = {
     english: 'EN',
     spanish: 'ES',
   },
-} as const;
+};
 
-// Export type for TypeScript autocomplete
+// Export type for TypeScript autocomplete (structure only, not literal values)
 export type TranslationKeys = typeof en;


### PR DESCRIPTION
- Add explicit string type annotations to error messages in hooks
- Fix useCallback dependency arrays (add language and t)
- Remove unused ChatMessage import from mock-data.ts
- Remove 'as const' from en.ts to allow flexible string values
- Production build now compiles successfully